### PR TITLE
New link to tutorial, new heading for components

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,14 +116,15 @@ sections:
     <div class="row">
       <div class="col-lg-12">
         <h3 class="text-center">Documentation</h3>
-        <p>Each piece of the platform includes its own documentation, but if you want to start playing with it, we recommend you to go to the open book we are writing about it:</p>
-        <p class="text-center"><i class="fa fa-book fa-2x"></i><a href="https://www.gitbook.com/book/grimoirelab/grimoirelab-training/details" target="_blank"> <strong>GrimoireLab Training</strong></a></p>
+        <p class="text-center">Each piece of the platform includes its own documentation, but if you want to start playing with it, we recommend you to go to the open book we are writing about it:</p>
+        <p class="text-center"><i class="fa fa-book fa-2x"></i><a href="https://www.gitbook.com/book/grimoirelab/training" target="_blank"> <strong>GrimoireLab Training Tutorial</strong></a></p>
       </div>
     </div>
 
     <div class="row">
       <div class="col-lg-12">
-        <p>The platform provides the following pieces:</p>
+        <h3 class="text-center">Components</h3>
+        <p>The platform provides the following components:</p>
       {% for project in site.data.projects %}
         {% capture modulo %}{{ forloop.index0 | modulo:3 }}{% endcapture %}
 


### PR DESCRIPTION
The GrimoireLab Training Tutorial has a new link, to simplify the url.
Added a new header for GrimoireLab components, so that the transition from Documentation to Components gets smoother.